### PR TITLE
Add admin mode: teacher authentication for signup/unregister

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,18 +5,45 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
-# Mount the static files directory
+security = HTTPBasic()
+
+# Load teacher credentials from JSON file
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
+teachers_file = current_dir / "teachers.json"
+with open(teachers_file) as f:
+    teachers_data = json.load(f)
+    TEACHERS = {t["username"]: t["password"] for t in teachers_data["teachers"]}
+
+
+def verify_teacher(credentials: HTTPBasicCredentials = Depends(security)):
+    """Verify that the request is from an authenticated teacher."""
+    expected_password = TEACHERS.get(credentials.username)
+    if expected_password is None or not secrets.compare_digest(
+        credentials.password.encode("utf-8"),
+        expected_password.encode("utf-8"),
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username
+
+
+# Mount the static files directory
+app.mount("/static", StaticFiles(directory=os.path.join(current_dir,
           "static")), name="static")
 
 # In-memory activity database
@@ -83,14 +110,20 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.get("/auth/login")
+def login(teacher: str = Depends(verify_teacher)):
+    """Verify teacher credentials and return the username."""
+    return {"message": "Login successful", "username": teacher}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, teacher: str = Depends(verify_teacher)):
+    """Sign up a student for an activity (teacher-only)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +144,8 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, teacher: str = Depends(verify_teacher)):
+    """Unregister a student from an activity (teacher-only)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,72 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authBtn = document.getElementById("auth-btn");
+  const loginModal = document.getElementById("login-modal");
+  const modalClose = document.getElementById("modal-close");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+
+  // Auth state
+  let authCredentials = null; // stores Base64 encoded credentials
+
+  // --- Auth UI ---
+  authBtn.addEventListener("click", () => {
+    if (authCredentials) {
+      // Logout
+      authCredentials = null;
+      authBtn.textContent = "👤 Login";
+      authBtn.title = "Teacher Login";
+      updateUI();
+      fetchActivities();
+    } else {
+      loginModal.classList.remove("hidden");
+    }
+  });
+
+  modalClose.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginMessage.classList.add("hidden");
+  });
+
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) {
+      loginModal.classList.add("hidden");
+      loginMessage.classList.add("hidden");
+    }
+  });
+
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    const encoded = btoa(username + ":" + password);
+
+    try {
+      const response = await fetch("/auth/login", {
+        headers: { Authorization: "Basic " + encoded },
+      });
+
+      if (response.ok) {
+        authCredentials = encoded;
+        authBtn.textContent = "👤 Logout (" + username + ")";
+        authBtn.title = "Click to logout";
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        updateUI();
+        loginMessage.classList.add("hidden");
+        fetchActivities();
+      } else {
+        loginMessage.textContent = "Invalid username or password";
+        loginMessage.className = "error";
+        loginMessage.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginMessage.textContent = "Login failed. Please try again.";
+      loginMessage.className = "error";
+      loginMessage.classList.remove("hidden");
+    }
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -21,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Create participants HTML with delete icons (only for teachers)
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +96,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        authCredentials
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -80,6 +150,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authCredentials
+            ? { Authorization: "Basic " + authCredentials }
+            : {},
         }
       );
 
@@ -114,6 +187,13 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!authCredentials) {
+      messageDiv.textContent = "Please login as a teacher to sign up students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +204,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { Authorization: "Basic " + authCredentials },
         }
       );
 
@@ -156,5 +237,15 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
+  function updateUI() {
+    const signupContainer = document.getElementById("signup-container");
+    if (authCredentials) {
+      signupContainer.classList.remove("hidden");
+    } else {
+      signupContainer.classList.add("hidden");
+    }
+  }
+
+  updateUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,30 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-section">
+        <button id="auth-btn" title="Teacher Login">👤 Login</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span id="modal-close" class="modal-close">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="Enter username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Login</button>
+          <div id="login-message" class="hidden"></div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,77 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+/* Auth section in header */
+#auth-section {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+}
+
+#auth-btn {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 8px 16px;
+  font-size: 14px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#auth-btn:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Login modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  position: relative;
+  color: #333;
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 10px;
+}
+
+.modal-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+  color: #666;
+}
+
+.modal-close:hover {
+  color: #333;
 }
 
 main {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,16 @@
+{
+  "teachers": [
+    {
+      "username": "headmaster",
+      "password": "mergington2024"
+    },
+    {
+      "username": "msjohnson",
+      "password": "teach@Math1"
+    },
+    {
+      "username": "mrsmith",
+      "password": "science#Lab2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds teacher authentication (admin mode) to prevent students from removing each other from activities.

## Changes

- **`src/teachers.json`** (new) — Teacher credentials file with 3 accounts
- **`src/app.py`** — HTTP Basic auth protecting signup/unregister endpoints, plus a `/auth/login` verification endpoint
- **`src/static/index.html`** — Login button in header + login modal dialog
- **`src/static/app.js`** — Auth state management, login/logout flow, conditional UI for teachers vs students
- **`src/static/styles.css`** — Styling for auth button, modal, and login form

## Behavior

- **Students (not logged in):** Can view all activities and participants, but cannot sign up or remove anyone
- **Teachers (logged in):** See the signup form and delete buttons, can register/unregister students
- **Login:** Click "👤 Login" in the top-right header, enter credentials
- **Logout:** Click "👤 Logout (username)" to return to student view

## Testing

All endpoints verified:
- `GET /activities` — public, returns 9 activities ✅
- `POST /activities/{name}/signup` — returns 401 without auth, 200 with teacher auth ✅
- `DELETE /activities/{name}/unregister` — returns 401 without auth ✅
- `GET /auth/login` — returns 200 + username with valid creds, 401 with bad creds ✅

Closes #5